### PR TITLE
Call client.leave on keyboard interrupt

### DIFF
--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -76,6 +76,9 @@ class BaseTransportService():
         except Exception as e:
             self._logger.error(f"Exception {e}")
             raise e
+        finally:
+            # Do anything that must be done to clean up
+            self._post_run()
 
         self._stop_threads.set()
 
@@ -86,6 +89,9 @@ class BaseTransportService():
 
         if self._speaker_enabled:
             self._receive_audio_thread.join()
+
+    def _post_run(self):
+        pass
 
     def stop(self):
         self._stop_threads.set()

--- a/src/dailyai/services/daily_transport_service.py
+++ b/src/dailyai/services/daily_transport_service.py
@@ -1,8 +1,8 @@
 import asyncio
 import inspect
 import logging
+import signal
 import threading
-import time
 import types
 
 from functools import partial
@@ -11,7 +11,7 @@ from dailyai.queue_frame import (
     TranscriptionQueueFrame,
 )
 
-from threading import Thread, Event
+from threading import Event
 
 from daily import (
     EventHandler,
@@ -193,6 +193,14 @@ class DailyTransportService(BaseTransportService, EventHandler):
 
         if self._token and self._start_transcription:
             self.client.start_transcription(self.transcription_settings)
+
+        signal.signal(signal.SIGINT, self.process_interrupt_handler)
+
+    def process_interrupt_handler(self, signum, frame):
+        self._post_run()
+
+    def _post_run(self):
+        self.client.leave()
 
     def on_first_other_participant_joined(self):
         pass


### PR DESCRIPTION
Add a signal handler and a `finally` block to call `client.leave` when the user presses CTRL-C or when the transport otherwise shuts down.