### PR TITLE
Queues instead of generators

### DIFF
--- a/src/dailyai/queue_aggregators.py
+++ b/src/dailyai/queue_aggregators.py
@@ -1,6 +1,15 @@
 import asyncio
 
-from dailyai.queue_frame import EndStreamQueueFrame, LLMMessagesQueueFrame, QueueFrame, TextQueueFrame, TranscriptionQueueFrame
+from attr import dataclass
+
+from dailyai.queue_frame import (
+    ControlQueueFrame,
+    EndStreamQueueFrame,
+    LLMMessagesQueueFrame,
+    QueueFrame,
+    TextQueueFrame,
+    TranscriptionQueueFrame,
+)
 from dailyai.services.ai_services import AIService, PipeService
 
 from typing import Any, AsyncGenerator, Callable, List, Tuple
@@ -13,40 +22,51 @@ class SinkAndQueuePair:
 
 class QueueTee(PipeService):
     def __init__(
-        self, source: PipeService, sinks: list[PipeService]
+        self, sinks: list[PipeService], *args, **kwargs
     ):
-        self.source: PipeService = source
+        super().__init__(*args, **kwargs)
 
         self.sinks: List[SinkAndQueuePair] = []
         for sink in sinks:
-            pair = SinkAndQueuePair()
-            pair.sink = sink
-            pair.queue = asyncio.Queue()
+            pair = SinkAndQueuePair(sink, asyncio.Queue())
             self.sinks.append(pair)
+            sink.source_queue = pair.queue
 
     async def process_queue(self):
+        if not self.source_queue:
+            return
+
         while True:
-            frame = await self.source.sink_queue.get()
+            frame: QueueFrame = await self.source_queue.get()
+            print("got frame")
             for sink in self.sinks:
+                print("putting frame in sink")
                 await sink.queue.put(frame)
             if isinstance(frame, EndStreamQueueFrame):
                 break
 
 
-class QueueGateOnFrame(PipeService):
+class QueueFrameAggregator(PipeService):
 
     def __init__(
         self,
-        source: PipeService,
         aggregator: Callable[[Any, QueueFrame], Tuple[Any, QueueFrame | None]],
+        finalizer: Callable[[Any], QueueFrame | None],
+        *args,
+        **kwargs
     ):
-        self.source = source
+        super().__init__(*args, **kwargs)
         self.aggregator = aggregator
-        self.accumulation = None
+        self.finalizer = finalizer
+        self.aggregation = None
 
     async def process_frame(
         self, frame: QueueFrame
     ) -> AsyncGenerator[QueueFrame, None]:
+        if isinstance(frame, ControlQueueFrame):
+            yield frame
+            return
+
         output_frame: QueueFrame | None = None
         (self.aggregation, output_frame) = self.aggregator(
             self.aggregation, frame
@@ -54,37 +74,45 @@ class QueueGateOnFrame(PipeService):
         if output_frame:
             yield output_frame
 
+    async def finalize(self) -> AsyncGenerator[QueueFrame, None]:
+        output_frame = self.finalizer(self.aggregation)
+        if output_frame:
+            yield output_frame
+
 class QueueMergeGateOnFirst(PipeService):
 
     def __init__(
-        self, sources: List[PipeService], sink: asyncio.Queue[QueueFrame]
+        self, source_queues: List[asyncio.Queue[QueueFrame]]
     ):
-        self.sources = sources
-        self.sink = sink
+        super().__init__()
+        self.source_queues = source_queues
 
     async def process_queue(self):
         (frames): list[QueueFrame] = await asyncio.gather(
-            *[
-                source.sink_queue.get() for source in self.sources
-            ]
+            *[source_queue.get() for source_queue in self.source_queues]
         )
         for idx, frame in enumerate(frames):
-            await self.sink.put(frame)
+            print("frame", idx, frame)
 
-            # if the first frame we got from a source is an EndStreamQueueFrame, remove that source
+            # if the frame we got from a source is an EndStreamQueueFrame, remove that source
             if isinstance(frame, EndStreamQueueFrame):
-                self.sources.pop(idx)
+                self.source_queues.pop(idx)
+            else:
+                await self.sink_queue.put(frame)
 
         async def pass_through(sink, source):
             while True:
                 frame = await source.get()
-                await sink.put(frame)
                 if isinstance(frame, EndStreamQueueFrame):
                     break
+                else:
+                    await sink.put(frame)
 
         await asyncio.gather(
-            *[pass_through(self.sink, source) for source in self.sources]
+            *[pass_through(self.sink_queue, source) for source in self.source_queues]
         )
+
+        await self.sink_queue.put(EndStreamQueueFrame())
 
 
 class LLMContextAggregator(AIService):

--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -50,6 +50,10 @@ class PipeService(AbstractPipeService):
         self.source = source
         self.sink = sink
 
+    def chain(self, service: AbstractPipeService) -> AbstractPipeService:
+        self.source = service.sink
+        return self
+
     async def process_queue(self):
         if not self.source:
             return

--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -47,7 +47,6 @@ class PipeService(AbstractPipeService):
 
         while True:
             frame: QueueFrame = await self.source_queue.get()
-            print("got frame", frame.__class__.__name__)
             async for output_frame in self.process_frame(frame):
                 if isinstance(frame, EndStreamQueueFrame):
                     async for final_frame in self.finalize():

--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -187,7 +187,7 @@ class TTSService(AIService):
 
     # Convenience function to send the audio for a sentence to the given queue
     async def say(self, sentence, queue: asyncio.Queue|None=None):
-        queue = queue or self.output_queue
+        queue = queue or self.sink
         if not queue:
             raise Exception("No queue to send audio to")
         await self.run_to_queue(queue, [TextQueueFrame(sentence)])

--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -47,7 +47,6 @@ class PipeService(AbstractPipeService):
             frame: QueueFrame = await self.source_queue.get()
             async for output_frame in self.process_frame(frame):
                 if isinstance(frame, EndStreamQueueFrame):
-                    print("end of stream", type(self))
                     async for final_frame in self.finalize():
                         await self.sink_queue.put(final_frame)
                     await self.sink_queue.put(output_frame)

--- a/src/dailyai/services/azure_ai_services.py
+++ b/src/dailyai/services/azure_ai_services.py
@@ -48,8 +48,17 @@ class AzureTTSService(TTSService):
 
 
 class AzureLLMService(LLMService):
-    def __init__(self, *, api_key, endpoint, api_version="2023-12-01-preview", model):
-        super().__init__()
+
+    def __init__(
+        self,
+        api_key,
+        endpoint,
+        model,
+        api_version="2023-12-01-preview",
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
         self._model: str = model
 
         self._client = AsyncAzureOpenAI(

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -82,8 +82,10 @@ class BaseTransportService():
 
         self._stop_threads.set()
 
+        if self.send_queue:
+            await self.send_queue.put(EndStreamQueueFrame())
         await async_output_queue_marshal_task
-        await self.send_queue.join()
+        #await self.send_queue.join()
         self._frame_consumer_thread.join()
 
         if self._speaker_enabled:

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -82,7 +82,6 @@ class BaseTransportService():
 
         self._stop_threads.set()
 
-        #await self.send_queue.put(EndStreamQueueFrame())
         await async_output_queue_marshal_task
         await self.send_queue.join()
         self._frame_consumer_thread.join()

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -82,7 +82,7 @@ class BaseTransportService():
 
         self._stop_threads.set()
 
-        await self.send_queue.put(EndStreamQueueFrame())
+        #await self.send_queue.put(EndStreamQueueFrame())
         await async_output_queue_marshal_task
         await self.send_queue.join()
         self._frame_consumer_thread.join()

--- a/src/dailyai/services/daily_transport_service.py
+++ b/src/dailyai/services/daily_transport_service.py
@@ -205,7 +205,7 @@ class DailyTransportService(BaseTransportService, EventHandler):
     def _post_run(self):
         self.client.leave()
 
-    def on_first_other_participant_joined(self):
+    def on_first_other_participant_joined(self, participant):
         pass
 
     def call_joined(self, join_data, client_error):
@@ -226,7 +226,7 @@ class DailyTransportService(BaseTransportService, EventHandler):
     def on_participant_joined(self, participant):
         if not self._other_participant_has_joined and participant["id"] != self._my_participant_id:
             self._other_participant_has_joined = True
-            self.on_first_other_participant_joined()
+            self.on_first_other_participant_joined(participant)
 
     def on_participant_left(self, participant, reason):
         if len(self.client.participants()) < self._min_others_count + 1:

--- a/src/dailyai/services/elevenlabs_ai_service.py
+++ b/src/dailyai/services/elevenlabs_ai_service.py
@@ -12,12 +12,13 @@ class ElevenLabsTTSService(TTSService):
 
     def __init__(
         self,
-        *,
         aiohttp_session: aiohttp.ClientSession,
         api_key,
         voice_id,
+        *args,
+        **kwargs
     ):
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         self._api_key = api_key
         self._voice_id = voice_id

--- a/src/dailyai/services/playht_ai_service.py
+++ b/src/dailyai/services/playht_ai_service.py
@@ -11,12 +11,13 @@ class PlayHTAIService(TTSService):
 
     def __init__(
         self,
-        *,
         api_key,
         user_id,
-        voice_url
+        voice_url,
+        *args,
+        **kwargs,
     ):
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         self.speech_key = api_key
         self.user_id = user_id

--- a/src/dailyai/tests/test_daily_transport_service.py
+++ b/src/dailyai/tests/test_daily_transport_service.py
@@ -16,11 +16,11 @@ class TestDailyTransport(unittest.IsolatedAsyncioTestCase):
         was_called = False
 
         @transport.event_handler("on_first_other_participant_joined")
-        def test_event_handler(transport):
+        def test_event_handler(transport, participant):
             nonlocal was_called
             was_called = True
 
-        transport.on_first_other_participant_joined()
+        transport.on_first_other_participant_joined(None)
 
         self.assertTrue(was_called)
 
@@ -32,12 +32,12 @@ class TestDailyTransport(unittest.IsolatedAsyncioTestCase):
         event = asyncio.Event()
 
         @transport.event_handler("on_first_other_participant_joined")
-        async def test_event_handler(transport):
+        async def test_event_handler(transport, participant):
             nonlocal event
             await asyncio.sleep(0.1)
             event.set()
 
-        transport.on_first_other_participant_joined()
+        transport.on_first_other_participant_joined(None)
 
         await asyncio.wait_for(event.wait(), timeout=1)
         self.assertTrue(event.is_set())

--- a/src/dailyai/tests/test_pipe_aggregators.py
+++ b/src/dailyai/tests/test_pipe_aggregators.py
@@ -8,29 +8,29 @@ from dailyai.queue_aggregators import QueueFrameAggregator, QueueMergeGateOnFirs
 class IncomingPipeService(PipeService):
     def __init__(self):
         super().__init__()
-        self.sink_queue = asyncio.Queue()
+        self.out_queue = asyncio.Queue()
 
 class QueueTeeTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_queue_tee(self):
         originpipe = IncomingPipeService()
-        inpipe1 = PipeService(originpipe.sink_queue)
+        inpipe1 = PipeService(originpipe.out_queue)
         outpipe1 = PipeService()
         outpipe2 = PipeService()
-        teepipe = QueueTee(source_queue=inpipe1.sink_queue, sinks=[outpipe1, outpipe2])
+        teepipe = QueueTee(source_queue=inpipe1.out_queue, out_services=[outpipe1, outpipe2])
 
-        originpipe.sink_queue.put_nowait(TextQueueFrame("test"))
-        originpipe.sink_queue.put_nowait(EndStreamQueueFrame())
+        originpipe.out_queue.put_nowait(TextQueueFrame("test"))
+        originpipe.out_queue.put_nowait(EndStreamQueueFrame())
 
         await asyncio.gather(*[pipe.process_queue() for pipe in [originpipe, inpipe1, outpipe1, outpipe2, teepipe]])
 
         def validateOutputPipe(pipe: PipeService):
-            self.assertEqual(pipe.sink_queue.qsize(), 2)
-            frame = pipe.sink_queue.get_nowait()
+            self.assertEqual(pipe.out_queue.qsize(), 2)
+            frame = pipe.out_queue.get_nowait()
             self.assertIsInstance(frame, TextQueueFrame)
             if isinstance(frame, TextQueueFrame):
                 self.assertEqual(frame.text, "test")
-            self.assertIsInstance(pipe.sink_queue.get_nowait(), EndStreamQueueFrame)
+            self.assertIsInstance(pipe.out_queue.get_nowait(), EndStreamQueueFrame)
 
         validateOutputPipe(outpipe1)
         validateOutputPipe(outpipe2)
@@ -51,31 +51,31 @@ class QueueFrameAggregatorTest(unittest.IsolatedAsyncioTestCase):
 
         originpipe = IncomingPipeService()
         aggregator_pipe = QueueFrameAggregator(
-            source_queue=originpipe.sink_queue,
+            source_queue=originpipe.out_queue,
             aggregator=aggregate_sentences,
             finalizer=finalize_sentences,
         )
 
-        originpipe.sink_queue.put_nowait(TextQueueFrame("testing, "))
-        originpipe.sink_queue.put_nowait(TextQueueFrame("one."))
-        originpipe.sink_queue.put_nowait(TextQueueFrame("two."))
-        originpipe.sink_queue.put_nowait(TextQueueFrame("three."))
-        originpipe.sink_queue.put_nowait(TextQueueFrame("can you "))
-        originpipe.sink_queue.put_nowait(TextQueueFrame("hear me"))
-        originpipe.sink_queue.put_nowait(EndStreamQueueFrame())
+        originpipe.out_queue.put_nowait(TextQueueFrame("testing, "))
+        originpipe.out_queue.put_nowait(TextQueueFrame("one."))
+        originpipe.out_queue.put_nowait(TextQueueFrame("two."))
+        originpipe.out_queue.put_nowait(TextQueueFrame("three."))
+        originpipe.out_queue.put_nowait(TextQueueFrame("can you "))
+        originpipe.out_queue.put_nowait(TextQueueFrame("hear me"))
+        originpipe.out_queue.put_nowait(EndStreamQueueFrame())
 
         await asyncio.gather(originpipe.process_queue(), aggregator_pipe.process_queue())
 
-        self.assertEqual(aggregator_pipe.sink_queue.qsize(), 5)
+        self.assertEqual(aggregator_pipe.out_queue.qsize(), 5)
         expected_text = ["testing, one.", "two.", "three.", "can you hear me"]
         for exepectation in expected_text:
-            frame = aggregator_pipe.sink_queue.get_nowait()
+            frame = aggregator_pipe.out_queue.get_nowait()
             print(frame)
             self.assertIsInstance(frame, TextQueueFrame)
             if isinstance(frame, TextQueueFrame):
                 self.assertEqual(frame.text, exepectation)
 
-        self.assertIsInstance(aggregator_pipe.sink_queue.get_nowait(), EndStreamQueueFrame)
+        self.assertIsInstance(aggregator_pipe.out_queue.get_nowait(), EndStreamQueueFrame)
 
 class QueueMergeGateOnFirstTest(unittest.IsolatedAsyncioTestCase):
     async def test_queue_merge_gate_on_first(self):
@@ -83,42 +83,42 @@ class QueueMergeGateOnFirstTest(unittest.IsolatedAsyncioTestCase):
         pipe2 = IncomingPipeService()
 
         merge_pipe = QueueMergeGateOnFirst(
-            source_queues=[pipe1.sink_queue, pipe2.sink_queue],
+            source_queues=[pipe1.out_queue, pipe2.out_queue],
         )
 
         evt = asyncio.Event()
 
         async def add_items_to_first_pipe():
             await evt.wait()
-            await pipe1.sink_queue.put(TextQueueFrame("pipe1.1"))
-            await pipe1.sink_queue.put(TextQueueFrame("pipe1.2"))
-            await pipe1.sink_queue.put(EndStreamQueueFrame())
+            await pipe1.out_queue.put(TextQueueFrame("pipe1.1"))
+            await pipe1.out_queue.put(TextQueueFrame("pipe1.2"))
+            await pipe1.out_queue.put(EndStreamQueueFrame())
 
         async def add_items_to_second_pipe():
-            await pipe2.sink_queue.put(TextQueueFrame("pipe2.1"))
+            await pipe2.out_queue.put(TextQueueFrame("pipe2.1"))
             evt.set()
-            await pipe2.sink_queue.put(EndStreamQueueFrame())
+            await pipe2.out_queue.put(EndStreamQueueFrame())
 
         await asyncio.gather(
             *[pipe.process_queue() for pipe in [pipe1, pipe2, merge_pipe]],
             add_items_to_first_pipe(),
             add_items_to_second_pipe())
 
-        self.assertEqual(merge_pipe.sink_queue.qsize(), 4)
-        frame = merge_pipe.sink_queue.get_nowait()
+        self.assertEqual(merge_pipe.out_queue.qsize(), 4)
+        frame = merge_pipe.out_queue.get_nowait()
         assert isinstance(frame, TextQueueFrame)
         if isinstance(frame, TextQueueFrame):
             self.assertEqual(frame.text, "pipe1.1")
 
-        frame = merge_pipe.sink_queue.get_nowait()
+        frame = merge_pipe.out_queue.get_nowait()
         assert isinstance(frame, TextQueueFrame)
         if isinstance(frame, TextQueueFrame):
             self.assertEqual(frame.text, "pipe2.1")
 
-        frame = merge_pipe.sink_queue.get_nowait()
+        frame = merge_pipe.out_queue.get_nowait()
         assert isinstance(frame, TextQueueFrame)
         if isinstance(frame, TextQueueFrame):
             self.assertEqual(frame.text, "pipe1.2")
 
-        frame = merge_pipe.sink_queue.get_nowait()
+        frame = merge_pipe.out_queue.get_nowait()
         assert isinstance(frame, EndStreamQueueFrame)

--- a/src/dailyai/tests/test_pipe_aggregators.py
+++ b/src/dailyai/tests/test_pipe_aggregators.py
@@ -1,0 +1,124 @@
+import asyncio
+import unittest
+
+from dailyai.queue_frame import EndStreamQueueFrame, TextQueueFrame
+from dailyai.services.ai_services import PipeService
+from dailyai.queue_aggregators import QueueFrameAggregator, QueueMergeGateOnFirst, QueueTee
+
+class IncomingPipeService(PipeService):
+    def __init__(self):
+        super().__init__()
+        self.sink_queue = asyncio.Queue()
+
+class QueueTeeTest(unittest.IsolatedAsyncioTestCase):
+
+    async def test_queue_tee(self):
+        originpipe = IncomingPipeService()
+        inpipe1 = PipeService(originpipe.sink_queue)
+        outpipe1 = PipeService()
+        outpipe2 = PipeService()
+        teepipe = QueueTee(source_queue=inpipe1.sink_queue, sinks=[outpipe1, outpipe2])
+
+        originpipe.sink_queue.put_nowait(TextQueueFrame("test"))
+        originpipe.sink_queue.put_nowait(EndStreamQueueFrame())
+
+        await asyncio.gather(*[pipe.process_queue() for pipe in [originpipe, inpipe1, outpipe1, outpipe2, teepipe]])
+
+        def validateOutputPipe(pipe: PipeService):
+            self.assertEqual(pipe.sink_queue.qsize(), 2)
+            frame = pipe.sink_queue.get_nowait()
+            self.assertIsInstance(frame, TextQueueFrame)
+            if isinstance(frame, TextQueueFrame):
+                self.assertEqual(frame.text, "test")
+            self.assertIsInstance(pipe.sink_queue.get_nowait(), EndStreamQueueFrame)
+
+        validateOutputPipe(outpipe1)
+        validateOutputPipe(outpipe2)
+
+class QueueFrameAggregatorTest(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_frame_aggregator(self):
+        def aggregate_sentences(accumulation, frame):
+            if not accumulation:
+                accumulation = ""
+            if isinstance(frame, TextQueueFrame):
+                accumulation += frame.text
+            if accumulation.endswith((".", "!", "?")):
+                return ("", TextQueueFrame(accumulation))
+            return (accumulation, None)
+
+        def finalize_sentences(accumulation):
+            return TextQueueFrame(accumulation)
+
+        originpipe = IncomingPipeService()
+        aggregator_pipe = QueueFrameAggregator(
+            source_queue=originpipe.sink_queue,
+            aggregator=aggregate_sentences,
+            finalizer=finalize_sentences,
+        )
+
+        originpipe.sink_queue.put_nowait(TextQueueFrame("testing, "))
+        originpipe.sink_queue.put_nowait(TextQueueFrame("one."))
+        originpipe.sink_queue.put_nowait(TextQueueFrame("two."))
+        originpipe.sink_queue.put_nowait(TextQueueFrame("three."))
+        originpipe.sink_queue.put_nowait(TextQueueFrame("can you "))
+        originpipe.sink_queue.put_nowait(TextQueueFrame("hear me"))
+        originpipe.sink_queue.put_nowait(EndStreamQueueFrame())
+
+        await asyncio.gather(originpipe.process_queue(), aggregator_pipe.process_queue())
+
+        self.assertEqual(aggregator_pipe.sink_queue.qsize(), 5)
+        expected_text = ["testing, one.", "two.", "three.", "can you hear me"]
+        for exepectation in expected_text:
+            frame = aggregator_pipe.sink_queue.get_nowait()
+            print(frame)
+            self.assertIsInstance(frame, TextQueueFrame)
+            if isinstance(frame, TextQueueFrame):
+                self.assertEqual(frame.text, exepectation)
+
+        self.assertIsInstance(aggregator_pipe.sink_queue.get_nowait(), EndStreamQueueFrame)
+
+class QueueMergeGateOnFirstTest(unittest.IsolatedAsyncioTestCase):
+    async def test_queue_merge_gate_on_first(self):
+        pipe1 = IncomingPipeService()
+        pipe2 = IncomingPipeService()
+
+        merge_pipe = QueueMergeGateOnFirst(
+            source_queues=[pipe1.sink_queue, pipe2.sink_queue],
+        )
+
+        evt = asyncio.Event()
+
+        async def add_items_to_first_pipe():
+            await evt.wait()
+            await pipe1.sink_queue.put(TextQueueFrame("pipe1.1"))
+            await pipe1.sink_queue.put(TextQueueFrame("pipe1.2"))
+            await pipe1.sink_queue.put(EndStreamQueueFrame())
+
+        async def add_items_to_second_pipe():
+            await pipe2.sink_queue.put(TextQueueFrame("pipe2.1"))
+            evt.set()
+            await pipe2.sink_queue.put(EndStreamQueueFrame())
+
+        await asyncio.gather(
+            *[pipe.process_queue() for pipe in [pipe1, pipe2, merge_pipe]],
+            add_items_to_first_pipe(),
+            add_items_to_second_pipe())
+
+        self.assertEqual(merge_pipe.sink_queue.qsize(), 4)
+        frame = merge_pipe.sink_queue.get_nowait()
+        assert isinstance(frame, TextQueueFrame)
+        if isinstance(frame, TextQueueFrame):
+            self.assertEqual(frame.text, "pipe1.1")
+
+        frame = merge_pipe.sink_queue.get_nowait()
+        assert isinstance(frame, TextQueueFrame)
+        if isinstance(frame, TextQueueFrame):
+            self.assertEqual(frame.text, "pipe2.1")
+
+        frame = merge_pipe.sink_queue.get_nowait()
+        assert isinstance(frame, TextQueueFrame)
+        if isinstance(frame, TextQueueFrame):
+            self.assertEqual(frame.text, "pipe1.2")
+
+        frame = merge_pipe.sink_queue.get_nowait()
+        assert isinstance(frame, EndStreamQueueFrame)

--- a/src/dailyai/tests/test_pipe_service.py
+++ b/src/dailyai/tests/test_pipe_service.py
@@ -1,10 +1,33 @@
+import asyncio
+from math import pi
 import unittest
 
 from unittest.mock import MagicMock, patch
 
-from dailyai.queue_frame import AudioQueueFrame, ImageQueueFrame
+from dailyai.queue_frame import AudioQueueFrame, EndStreamQueueFrame, ImageQueueFrame, TextQueueFrame
 from dailyai.services.ai_services import PipeService
 
 class TestDailyTransport(unittest.IsolatedAsyncioTestCase):
-    def test_pipe_chain(self):
-        pipe1 = PipeService()
+    class IncomingPipeService(PipeService):
+        def __init__(self):
+            super().__init__()
+            self.sink_queue = asyncio.Queue()
+
+    async def test_pipe_chain(self):
+        pipe1 = TestDailyTransport.IncomingPipeService()
+        pipe2 = PipeService(pipe1)
+        pipe3 = PipeService(pipe2)
+
+        await pipe1.sink_queue.put(TextQueueFrame("test"))
+        await pipe1.sink_queue.put(EndStreamQueueFrame())
+
+        await asyncio.gather(pipe1.process_queue(), pipe2.process_queue(), pipe3.process_queue())
+
+        self.assertEqual(pipe3.sink_queue.qsize(), 2)
+        frame = await pipe3.sink_queue.get()
+        self.assertIsInstance(frame, TextQueueFrame)
+        if isinstance(frame, TextQueueFrame):
+            self.assertEqual(frame.text, "test")
+
+        frame = await pipe3.sink_queue.get()
+        self.assertIsInstance(frame, EndStreamQueueFrame)

--- a/src/dailyai/tests/test_pipe_service.py
+++ b/src/dailyai/tests/test_pipe_service.py
@@ -1,0 +1,10 @@
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+from dailyai.queue_frame import AudioQueueFrame, ImageQueueFrame
+from dailyai.services.ai_services import PipeService
+
+class TestDailyTransport(unittest.IsolatedAsyncioTestCase):
+    def test_pipe_chain(self):
+        pipe1 = PipeService()

--- a/src/dailyai/tests/test_pipe_service.py
+++ b/src/dailyai/tests/test_pipe_service.py
@@ -15,8 +15,8 @@ class TestPipeService(unittest.IsolatedAsyncioTestCase):
         pipe2 = PipeService(pipe1.out_queue)
         pipe3 = PipeService(pipe2.out_queue)
 
-        await pipe1.out_queue.put(TextQueueFrame("test"))
-        await pipe1.out_queue.put(EndStreamQueueFrame())
+        await pipe1.source_queue.put(TextQueueFrame("test"))
+        await pipe1.source_queue.put(EndStreamQueueFrame())
 
         await asyncio.gather(pipe1.process_queue(), pipe2.process_queue(), pipe3.process_queue())
 

--- a/src/dailyai/tests/test_pipe_service.py
+++ b/src/dailyai/tests/test_pipe_service.py
@@ -8,23 +8,23 @@ class TestPipeService(unittest.IsolatedAsyncioTestCase):
     class IncomingPipeService(PipeService):
         def __init__(self):
             super().__init__()
-            self.sink_queue = asyncio.Queue()
+            self.out_queue = asyncio.Queue()
 
     async def test_pipe_chain(self):
         pipe1 = TestPipeService.IncomingPipeService()
-        pipe2 = PipeService(pipe1.sink_queue)
-        pipe3 = PipeService(pipe2.sink_queue)
+        pipe2 = PipeService(pipe1.out_queue)
+        pipe3 = PipeService(pipe2.out_queue)
 
-        await pipe1.sink_queue.put(TextQueueFrame("test"))
-        await pipe1.sink_queue.put(EndStreamQueueFrame())
+        await pipe1.out_queue.put(TextQueueFrame("test"))
+        await pipe1.out_queue.put(EndStreamQueueFrame())
 
         await asyncio.gather(pipe1.process_queue(), pipe2.process_queue(), pipe3.process_queue())
 
-        self.assertEqual(pipe3.sink_queue.qsize(), 2)
-        frame = await pipe3.sink_queue.get()
+        self.assertEqual(pipe3.out_queue.qsize(), 2)
+        frame = await pipe3.out_queue.get()
         self.assertIsInstance(frame, TextQueueFrame)
         if isinstance(frame, TextQueueFrame):
             self.assertEqual(frame.text, "test")
 
-        frame = await pipe3.sink_queue.get()
+        frame = await pipe3.out_queue.get()
         self.assertIsInstance(frame, EndStreamQueueFrame)

--- a/src/dailyai/tests/test_pipe_service.py
+++ b/src/dailyai/tests/test_pipe_service.py
@@ -1,22 +1,19 @@
 import asyncio
-from math import pi
 import unittest
 
-from unittest.mock import MagicMock, patch
-
-from dailyai.queue_frame import AudioQueueFrame, EndStreamQueueFrame, ImageQueueFrame, TextQueueFrame
+from dailyai.queue_frame import EndStreamQueueFrame, TextQueueFrame
 from dailyai.services.ai_services import PipeService
 
-class TestDailyTransport(unittest.IsolatedAsyncioTestCase):
+class TestPipeService(unittest.IsolatedAsyncioTestCase):
     class IncomingPipeService(PipeService):
         def __init__(self):
             super().__init__()
             self.sink_queue = asyncio.Queue()
 
     async def test_pipe_chain(self):
-        pipe1 = TestDailyTransport.IncomingPipeService()
-        pipe2 = PipeService(pipe1)
-        pipe3 = PipeService(pipe2)
+        pipe1 = TestPipeService.IncomingPipeService()
+        pipe2 = PipeService(pipe1.sink_queue)
+        pipe3 = PipeService(pipe2.sink_queue)
 
         await pipe1.sink_queue.put(TextQueueFrame("test"))
         await pipe1.sink_queue.put(EndStreamQueueFrame())

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -1,6 +1,7 @@
 import asyncio
 import aiohttp
 import os
+from dailyai.queue_frame import EndStreamQueueFrame
 
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
@@ -42,15 +43,14 @@ async def main(room_url):
         )
 
         # Register an event handler so we can play the audio when the participant joins.
-        @transport.event_handler("on_participant_joined")
-        async def on_participant_joined(transport, participant):
+        @transport.event_handler("on_first_other_participant_joined")
+        async def on_first_other_participant_joined(transport, participant):
             nonlocal tts
-            if participant["info"]["isLocal"]:
-                return
 
             await tts.say(
                 "Hello there, " + participant["info"]["userName"] + "!"
             )
+            await tts.sink.put(EndStreamQueueFrame())
 
             # wait for the output queue to be empty, then leave the meeting
             await transport.stop_when_done()

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -36,7 +36,7 @@ async def main(room_url):
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"))
         """
         tts = PlayHTAIService(
-            sink=transport.send_queue,
+            out_queue=transport.send_queue,
             api_key=os.getenv("PLAY_HT_API_KEY"),
             user_id=os.getenv("PLAY_HT_USER_ID"),
             voice_url=os.getenv("PLAY_HT_VOICE_URL"),
@@ -50,7 +50,7 @@ async def main(room_url):
             await tts.say(
                 "Hello there, " + participant["info"]["userName"] + "!"
             )
-            await tts.sink.put(EndStreamQueueFrame())
+            await tts.source_queue.put(EndStreamQueueFrame())
 
             # wait for the output queue to be empty, then leave the meeting
             await transport.stop_when_done()

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -35,7 +35,6 @@ async def main(room_url):
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"))
         """
         tts = PlayHTAIService(
-            source=None,
             sink=transport.send_queue,
             api_key=os.getenv("PLAY_HT_API_KEY"),
             user_id=os.getenv("PLAY_HT_USER_ID"),

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -35,6 +35,8 @@ async def main(room_url):
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"))
         """
         tts = PlayHTAIService(
+            source=None,
+            sink=transport.send_queue,
             api_key=os.getenv("PLAY_HT_API_KEY"),
             user_id=os.getenv("PLAY_HT_USER_ID"),
             voice_url=os.getenv("PLAY_HT_VOICE_URL"),
@@ -48,8 +50,7 @@ async def main(room_url):
                 return
 
             await tts.say(
-                "Hello there, " + participant["info"]["userName"] + "!",
-                transport.send_queue,
+                "Hello there, " + participant["info"]["userName"] + "!"
             )
 
             # wait for the output queue to be empty, then leave the meeting

--- a/src/examples/foundational/02-llm-say-one-thing.py
+++ b/src/examples/foundational/02-llm-say-one-thing.py
@@ -30,12 +30,11 @@ async def main(room_url):
         )
 
         tts = ElevenLabsTTSService(
-            source=llm,
             sink=transport.send_queue,
             aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             voice_id=os.getenv("ELEVENLABS_VOICE_ID"),
-        )
+        ).chain(llm)
 
         messages = [{
             "role": "system",

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -92,8 +92,9 @@ async def main(room_url):
         tts_image_gate.out_queue = transport.send_queue
 
         # Queue up all the months in the LLM service source queue
-        months = ["January"] #, "February"]
+        months = ["January", "February", "March", "April"]
         for month in months:
+            print(f"building pipeline for {month}")
             messages = [
                 {
                     "role": "system",
@@ -102,7 +103,6 @@ async def main(room_url):
             ]
 
             await month_description_queue.put(LLMMessagesQueueFrame(messages))
-
         await month_description_queue.put(EndStreamQueueFrame())
 
         pipeline = [
@@ -115,7 +115,7 @@ async def main(room_url):
             transport,
         ]
 
-        await asyncio.gather(transport.run(), *[service.process_queue() for service in [llm, tts, dalle, tee, tts_image_gate, llm_aggregator_for_image]])
+        await asyncio.gather(transport.run(),*[service.process_queue() for service in [llm, tts, dalle, tee, tts_image_gate, llm_aggregator_for_image]])
 
 if __name__ == "__main__":
     (url, token) = configure()

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -105,6 +105,16 @@ async def main(room_url):
 
         await month_description_queue.put(EndStreamQueueFrame())
 
+        pipeline = [
+            llm,
+            [tee,
+             [tts,
+              [llm_aggregator_for_image, dalle]
+             ],
+            tts_image_gate],
+            transport,
+        ]
+
         await asyncio.gather(transport.run(), *[service.process_queue() for service in [llm, tts, dalle, tee, tts_image_gate, llm_aggregator_for_image]])
 
 if __name__ == "__main__":

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -1,8 +1,10 @@
 import asyncio
+from typing import Any, AsyncGenerator, Callable, Tuple
 import aiohttp
 import os
 
-from dailyai.queue_frame import AudioQueueFrame, ImageQueueFrame
+from dailyai.queue_frame import AudioQueueFrame, EndStreamQueueFrame, ImageQueueFrame, LLMResponseEndQueueFrame, QueueFrame, TextQueueFrame
+from dailyai.services.ai_services import PipeService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureImageGenServiceREST, AzureTTSService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from dailyai.services.daily_transport_service import DailyTransportService
@@ -27,23 +29,109 @@ async def main(room_url):
             camera_height=1024
         )
 
+        """
+
+                                      / TTS      \
+        Month prompt -> LLM -> Fork ->            -> Gate -> Transport
+                                      \ ImageGen /
+        """
+
+        class QueueFork(PipeService):
+            def __init__(self, source:PipeService, sinks: list[asyncio.Queue[QueueFrame]]):
+                self.source = source
+                self.sinks = sinks
+
+            async def process_queue(self):
+                while True:
+                    frame = await self.source.get()
+                    for sink in self.sinks:
+                        await sink.put(frame)
+                    if isinstance(frame, EndStreamQueueFrame):
+                        break
+
+
+        class QueueGateOnFrame(PipeService):
+
+            def __init__(
+                self,
+                source: asyncio.Queue[QueueFrame],
+                sink: asyncio.Queue[QueueFrame],
+                aggregator: Callable[[Any, QueueFrame], Tuple[Any, QueueFrame | None]]
+            ):
+                self.source = source
+                self.sink = sink
+                self.aggregator = aggregator
+                self.accumulation = None
+
+            async def process_frame(
+                self, frame: QueueFrame
+            ) -> AsyncGenerator[QueueFrame, None]:
+                output_frame: QueueFrame | None = None
+                (self.aggregation, output_frame) = self.aggregator(
+                    self.aggregation, frame
+                )
+                if output_frame:
+                    yield output_frame
+
+        class QueueMergeGateOnFirst(PipeService):
+
+            def __init__(
+                self, queue_fork_service: QueueFork, sink: asyncio.Queue[QueueFrame]
+            ):
+                self.queue_fork_service = queue_fork_service
+                self.sink = sink
+
+            async def process_queue(self):
+                (frames): list[QueueFrame] = await asyncio.gather(
+                    *[source.get() for source in self.queue_fork_service.get_end_sinks()]
+                )
+                for idx, frame in enumerate(frames):
+                    await self.sink.put(frame)
+
+                    # if the first frame we got from a source is an EndStreamQueueFrame, remove that source
+                    if isinstance(frame, EndStreamQueueFrame):
+                        self.sources.pop(idx)
+
+                async def pass_through(sink, source):
+                    while True:
+                        frame = await source.get()
+                        await sink.put(frame)
+                        if isinstance(frame, EndStreamQueueFrame):
+                            break
+
+                await asyncio.gather(*[pass_through(self.sink, source) for source in self.sources])
+
         llm = AzureLLMService(
             api_key=os.getenv("AZURE_CHATGPT_API_KEY"),
             endpoint=os.getenv("AZURE_CHATGPT_ENDPOINT"),
             model=os.getenv("AZURE_CHATGPT_MODEL"))
+
         tts = ElevenLabsTTSService(
             aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
             voice_id="ErXwobaYiN019PkySvjV")
-        # tts = AzureTTSService(api_key=os.getenv("AZURE_SPEECH_API_KEY"), region=os.getenv("AZURE_SPEECH_REGION"))
 
         dalle = FalImageGenService(
             image_size="1024x1024",
             aiohttp_session=session,
             key_id=os.getenv("FAL_KEY_ID"),
-            key_secret=os.getenv("FAL_KEY_SECRET"))
-        # dalle = OpenAIImageGenService(aiohttp_session=session, api_key=os.getenv("OPENAI_DALLE_API_KEY"), image_size="1024x1024")
-        # dalle = AzureImageGenServiceREST(image_size="1024x1024", aiohttp_session=session, api_key=os.getenv("AZURE_DALLE_API_KEY"), endpoint=os.getenv("AZURE_DALLE_ENDPOINT"), model=os.getenv("AZURE_DALLE_MODEL"))
+            key_secret=os.getenv("FAL_KEY_SECRET"),
+        )
+
+        def aggregator(
+            accumulation, frame: QueueFrame
+        ) -> tuple[Any, QueueFrame | None]:
+            if isinstance(frame, TextQueueFrame):
+                accumulation += frame.text
+                return (accumulation, None)
+            elif isinstance(frame, LLMResponseEndQueueFrame):
+                return ("", TextQueueFrame(accumulation))
+            else:
+                return (accumulation, frame)
+
+        llm_image_gate = QueueGateOnFrame(llm.sink, dalle.source, aggregator)
+        fork_audio_image = QueueFork(llm.sink, [tts.source, llm_image_gate.source])
+        audio_image_gate = QueueMergeGateOnFirst([tts.sink, dalle.sink], transport.send_queue)
 
         # Get a complete audio chunk from the given text. Splitting this into its own
         # coroutine lets us ensure proper ordering of the audio chunks on the send queue.


### PR DESCRIPTION
This is _far_ from done, but starting to sketch this out.

Made new `AbstractPipeService` and `PipeService` classes. These basically contain logic to pull a frame off a source queue, process that frame, and put it and/or other frames onto an outgoing sink queue. `AIService` is now a child class of `PipeService` so it has this functionality in addition to the AsyncGenerator-style `run` functionality.

Still working on:
* figuring out how this fits with the transport service. It feels like the transport service actually contains two pipe services, for the incoming pipe and the outgoing pipe. Gonna play with this today.
* how to "chain" these pipe services together in a way that feels good. I have a `chain` method now but I'm not sure this is the right path. It might be that specifying a list is fine, then whatever "runs" the conversation links 'em up. Or maybe this is obviated by Chad's callback idea. Still noodling on this.

Anyway, incomplete as yet but wanted to share as soon as I had something _moderately_ share-able.