### PR TITLE
Remove Queue in frame names

### DIFF
--- a/src/dailyai/pipeline/frame_processor.py
+++ b/src/dailyai/pipeline/frame_processor.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from typing import AsyncGenerator
 
-from dailyai.pipeline.frames import ControlQueueFrame, QueueFrame
+from dailyai.pipeline.frames import ControlFrame, Frame
 
 """
 This is the base class for all frame processors. Frame processors consume a frame
@@ -20,16 +20,16 @@ be closed, del'd, etc.
 class FrameProcessor:
     @abstractmethod
     async def process_frame(
-        self, frame: QueueFrame
-    ) -> AsyncGenerator[QueueFrame, None]:
-        if isinstance(frame, ControlQueueFrame):
+        self, frame: Frame
+    ) -> AsyncGenerator[Frame, None]:
+        if isinstance(frame, ControlFrame):
             yield frame
 
     @abstractmethod
-    async def finalize(self) -> AsyncGenerator[QueueFrame, None]:
+    async def finalize(self) -> AsyncGenerator[Frame, None]:
         # This is a trick for the interpreter (and linter) to know that this is a generator.
         if False:
-            yield QueueFrame()
+            yield Frame()
 
     @abstractmethod
     async def interrupted(self) -> None:

--- a/src/dailyai/pipeline/frames.py
+++ b/src/dailyai/pipeline/frames.py
@@ -2,72 +2,73 @@ from dataclasses import dataclass
 from typing import Any
 
 
-class QueueFrame:
+class Frame:
+    pass
+
+class ControlFrame(Frame):
+    # Control frames should contain no instance data, so
+    # equality is based solely on the class.
     def __eq__(self, other):
-        return isinstance(other, self.__class__)
+        return type(other) == self.__class__
 
 
-class ControlQueueFrame(QueueFrame):
+class StartFrame(ControlFrame):
     pass
 
 
-class StartStreamQueueFrame(ControlQueueFrame):
+class EndFrame(ControlFrame):
+    pass
+
+class EndPipeFrame(ControlFrame):
     pass
 
 
-class EndStreamQueueFrame(ControlQueueFrame):
-    pass
-
-class EndParallelPipeQueueFrame(ControlQueueFrame):
+class LLMResponseStartFrame(ControlFrame):
     pass
 
 
-class LLMResponseStartQueueFrame(QueueFrame):
-    pass
-
-
-class LLMResponseEndQueueFrame(QueueFrame):
+class LLMResponseEndFrame(ControlFrame):
     pass
 
 
 @dataclass()
-class AudioQueueFrame(QueueFrame):
+class AudioFrame(Frame):
     data: bytes
 
 
 @dataclass()
-class ImageQueueFrame(QueueFrame):
+class ImageFrame(Frame):
     url: str | None
     image: bytes
 
 
 @dataclass()
-class SpriteQueueFrame(QueueFrame):
+class SpriteFrame(Frame):
     images: list[bytes]
 
 
 @dataclass()
-class TextQueueFrame(QueueFrame):
+class TextFrame(Frame):
     text: str
 
 
 @dataclass()
-class TranscriptionQueueFrame(TextQueueFrame):
+class TranscriptionQueueFrame(TextFrame):
     participantId: str
     timestamp: str
 
 
 @dataclass()
-class LLMMessagesQueueFrame(QueueFrame):
+class LLMMessagesQueueFrame(Frame):
     messages: list[dict[str, str]]  # TODO: define this more concretely!
 
 
-class AppMessageQueueFrame(QueueFrame):
+class AppMessageQueueFrame(Frame):
     message: Any
     participantId: str
 
-class UserStartedSpeakingFrame(QueueFrame):
+class UserStartedSpeakingFrame(Frame):
     pass
 
-class UserStoppedSpeakingFrame(QueueFrame):
+class UserStoppedSpeakingFrame(Frame):
     pass

--- a/src/dailyai/services/local_stt_service.py
+++ b/src/dailyai/services/local_stt_service.py
@@ -4,7 +4,7 @@ import math
 import time
 from typing import AsyncGenerator
 import wave
-from dailyai.pipeline.frames import AudioQueueFrame, QueueFrame, TranscriptionQueueFrame
+from dailyai.pipeline.frames import AudioFrame, Frame, TranscriptionQueueFrame
 from dailyai.services.ai_services import STTService
 
 
@@ -39,9 +39,9 @@ class LocalSTTService(STTService):
         ww.setframerate(self._frame_rate)
         self._wave = ww
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
         """Processes a frame of audio data, either buffering or transcribing it."""
-        if not isinstance(frame, AudioQueueFrame):
+        if not isinstance(frame, AudioFrame):
             return
 
         data = frame.data

--- a/src/dailyai/tests/test_ai_services.py
+++ b/src/dailyai/tests/test_ai_services.py
@@ -3,11 +3,11 @@ import unittest
 from typing import AsyncGenerator, Generator
 
 from dailyai.services.ai_services import AIService
-from dailyai.pipeline.frames import EndStreamQueueFrame, QueueFrame, TextQueueFrame
+from dailyai.pipeline.frames import EndFrame, Frame, TextFrame
 
 
 class SimpleAIService(AIService):
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
         yield frame
 
 
@@ -16,11 +16,11 @@ class TestBaseAIService(unittest.IsolatedAsyncioTestCase):
         service = SimpleAIService()
 
         input_frames = [
-            TextQueueFrame("hello"),
-            EndStreamQueueFrame()
+            TextFrame("hello"),
+            EndFrame()
         ]
 
-        async def iterate_frames() -> AsyncGenerator[QueueFrame, None]:
+        async def iterate_frames() -> AsyncGenerator[Frame, None]:
             for frame in input_frames:
                 yield frame
 
@@ -33,9 +33,9 @@ class TestBaseAIService(unittest.IsolatedAsyncioTestCase):
     async def test_nonasync_input(self):
         service = SimpleAIService()
 
-        input_frames = [TextQueueFrame("hello"), EndStreamQueueFrame()]
+        input_frames = [TextFrame("hello"), EndFrame()]
 
-        def iterate_frames() -> Generator[QueueFrame, None, None]:
+        def iterate_frames() -> Generator[Frame, None, None]:
             for frame in input_frames:
                 yield frame
 

--- a/src/dailyai/tests/test_daily_transport_service.py
+++ b/src/dailyai/tests/test_daily_transport_service.py
@@ -3,7 +3,7 @@ import unittest
 
 from unittest.mock import MagicMock, patch
 
-from dailyai.pipeline.frames import AudioQueueFrame, ImageQueueFrame
+from dailyai.pipeline.frames import AudioFrame, ImageFrame
 
 
 class TestDailyTransport(unittest.IsolatedAsyncioTestCase):

--- a/src/dailyai/tests/test_pipeline.py
+++ b/src/dailyai/tests/test_pipeline.py
@@ -2,7 +2,7 @@ import asyncio
 from doctest import OutputChecker
 import unittest
 from dailyai.pipeline.aggregators import SentenceAggregator, StatelessTextTransformer
-from dailyai.pipeline.frames import EndStreamQueueFrame, TextQueueFrame
+from dailyai.pipeline.frames import EndFrame, TextFrame
 
 from dailyai.pipeline.pipeline import Pipeline
 
@@ -16,14 +16,14 @@ class TestDailyPipeline(unittest.IsolatedAsyncioTestCase):
         incoming_queue = asyncio.Queue()
         pipeline = Pipeline([aggregator], incoming_queue, outgoing_queue)
 
-        await incoming_queue.put(TextQueueFrame("Hello, "))
-        await incoming_queue.put(TextQueueFrame("world."))
-        await incoming_queue.put(EndStreamQueueFrame())
+        await incoming_queue.put(TextFrame("Hello, "))
+        await incoming_queue.put(TextFrame("world."))
+        await incoming_queue.put(EndFrame())
 
         await pipeline.run_pipeline()
 
-        self.assertEqual(await outgoing_queue.get(), TextQueueFrame("Hello, world."))
-        self.assertIsInstance(await outgoing_queue.get(), EndStreamQueueFrame)
+        self.assertEqual(await outgoing_queue.get(), TextFrame("Hello, world."))
+        self.assertIsInstance(await outgoing_queue.get(), EndFrame)
 
     async def test_pipeline_multiple_stages(self):
         sentence_aggregator = SentenceAggregator()
@@ -40,21 +40,21 @@ class TestDailyPipeline(unittest.IsolatedAsyncioTestCase):
 
         sentence = "Hello, world. It's me, a pipeline."
         for c in sentence:
-            await incoming_queue.put(TextQueueFrame(c))
-        await incoming_queue.put(EndStreamQueueFrame())
+            await incoming_queue.put(TextFrame(c))
+        await incoming_queue.put(EndFrame())
 
         await pipeline.run_pipeline()
 
         self.assertEqual(
-            await outgoing_queue.get(), TextQueueFrame("H E L L O ,   W O R L D .")
+            await outgoing_queue.get(), TextFrame("H E L L O ,   W O R L D .")
         )
         self.assertEqual(
             await outgoing_queue.get(),
-            TextQueueFrame("   I T ' S   M E ,   A   P I P E L I N E ."),
+            TextFrame("   I T ' S   M E ,   A   P I P E L I N E ."),
         )
         # leftover little bit because of the spacing
         self.assertEqual(
             await outgoing_queue.get(),
-            TextQueueFrame(" "),
+            TextFrame(" "),
         )
-        self.assertIsInstance(await outgoing_queue.get(), EndStreamQueueFrame)
+        self.assertIsInstance(await outgoing_queue.get(), EndFrame)

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -28,7 +28,6 @@ async def main(room_url):
             mic_enabled=True
         )
 
-        """
         tts = ElevenLabsTTSService(
             aiohttp_session=session,
             api_key=os.getenv("ELEVENLABS_API_KEY"),
@@ -39,6 +38,7 @@ async def main(room_url):
             user_id=os.getenv("PLAY_HT_USER_ID"),
             voice_url=os.getenv("PLAY_HT_VOICE_URL"),
         )
+        """
 
         # Register an event handler so we can play the audio when the participant joins.
         @transport.event_handler("on_participant_joined")

--- a/src/examples/foundational/03-still-frame.py
+++ b/src/examples/foundational/03-still-frame.py
@@ -2,7 +2,7 @@ import asyncio
 import aiohttp
 import os
 
-from dailyai.pipeline.frames import TextQueueFrame
+from dailyai.pipeline.frames import TextFrame
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.fal_ai_services import FalImageGenService
 from dailyai.services.open_ai_services import OpenAIImageGenService
@@ -39,7 +39,7 @@ async def main(room_url):
         image_task = asyncio.create_task(
             imagegen.run_to_queue(
                 transport.send_queue, [
-                    TextQueueFrame("a cat in the style of picasso")]))
+                    TextFrame("a cat in the style of picasso")]))
 
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):

--- a/src/examples/foundational/03a-image-local.py
+++ b/src/examples/foundational/03a-image-local.py
@@ -4,7 +4,7 @@ import os
 
 import tkinter as tk
 
-from dailyai.pipeline.frames import TextQueueFrame
+from dailyai.pipeline.frames import TextFrame
 from dailyai.services.fal_ai_services import FalImageGenService
 from dailyai.services.local_transport_service import LocalTransportService
 
@@ -34,7 +34,7 @@ async def main():
         )
         image_task = asyncio.create_task(
             imagegen.run_to_queue(
-                transport.send_queue, [TextQueueFrame("a cat in the style of picasso")]
+                transport.send_queue, [TextFrame("a cat in the style of picasso")]
             )
         )
 

--- a/src/examples/foundational/04-utterance-and-speech.py
+++ b/src/examples/foundational/04-utterance-and-speech.py
@@ -6,7 +6,7 @@ from dailyai.pipeline.pipeline import Pipeline
 
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
-from dailyai.pipeline.frames import EndStreamQueueFrame, LLMMessagesQueueFrame
+from dailyai.pipeline.frames import EndFrame, LLMMessagesQueueFrame
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 
 from examples.foundational.support.runner import configure
@@ -56,7 +56,7 @@ async def main(room_url: str):
                     frame = await buffer_queue.get()
                     await transport.send_queue.put(frame)
                     buffer_queue.task_done()
-                    if isinstance(frame, EndStreamQueueFrame):
+                    if isinstance(frame, EndFrame):
                         break
 
             await asyncio.gather(pipeline_run_task, buffer_to_send_queue())

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -4,7 +4,7 @@ import aiohttp
 import os
 from dailyai.pipeline.aggregators import GatedAggregator, LLMFullResponseAggregator, ParallelPipeline, SentenceAggregator
 
-from dailyai.pipeline.frames import AudioQueueFrame, EndStreamQueueFrame, ImageQueueFrame, LLMMessagesQueueFrame, LLMResponseStartQueueFrame
+from dailyai.pipeline.frames import AudioFrame, EndFrame, ImageFrame, LLMMessagesQueueFrame, LLMResponseStartFrame
 from dailyai.pipeline.pipeline import Pipeline
 from dailyai.services.azure_ai_services import AzureLLMService, AzureImageGenServiceREST, AzureTTSService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
@@ -56,11 +56,11 @@ async def main(room_url):
             ]
             await source_queue.put(LLMMessagesQueueFrame(messages))
 
-        await source_queue.put(EndStreamQueueFrame())
+        await source_queue.put(EndFrame())
 
         gated_aggregator = GatedAggregator(
-            gate_open_fn=lambda frame: isinstance(frame, ImageQueueFrame),
-            gate_close_fn=lambda frame: isinstance(frame, LLMResponseStartQueueFrame),
+            gate_open_fn=lambda frame: isinstance(frame, ImageFrame),
+            gate_close_fn=lambda frame: isinstance(frame, LLMResponseStartFrame),
             start_open=False,
         )
 

--- a/src/examples/foundational/05a-local-sync-speech-and-text.py
+++ b/src/examples/foundational/05a-local-sync-speech-and-text.py
@@ -4,7 +4,7 @@ import asyncio
 import tkinter as tk
 import os
 
-from dailyai.pipeline.frames import AudioQueueFrame, ImageQueueFrame
+from dailyai.pipeline.frames import AudioFrame, ImageFrame
 from dailyai.services.azure_ai_services import AzureLLMService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from dailyai.services.fal_ai_services import FalImageGenService
@@ -103,8 +103,8 @@ async def main(room_url):
                 if data:
                     await transport.send_queue.put(
                         [
-                            ImageQueueFrame(data["image_url"], data["image"]),
-                            AudioQueueFrame(data["audio"]),
+                            ImageFrame(data["image_url"], data["image"]),
+                            AudioFrame(data["audio"]),
                         ]
                     )
 

--- a/src/examples/foundational/06-listen-and-respond.py
+++ b/src/examples/foundational/06-listen-and-respond.py
@@ -55,7 +55,7 @@ async def main(room_url: str, token):
                 tts
             ],
         )
-        await transport.run_pipeline(pipeline)
+        await transport.run_uninterruptible_pipeline(pipeline)
 
     transport.transcription_settings["extra"]["endpointing"] = True
     transport.transcription_settings["extra"]["punctuate"] = True

--- a/src/examples/foundational/06a-image-sync.py
+++ b/src/examples/foundational/06a-image-sync.py
@@ -8,7 +8,7 @@ import time
 import urllib.parse
 
 from PIL import Image
-from dailyai.pipeline.frames import ImageQueueFrame, QueueFrame
+from dailyai.pipeline.frames import ImageFrame, Frame
 
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
@@ -27,10 +27,10 @@ class ImageSyncAggregator(AIService):
         self._waiting_image = Image.open(waiting_path)
         self._waiting_image_bytes = self._waiting_image.tobytes()
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
-        yield ImageQueueFrame(None, self._speaking_image_bytes)
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
+        yield ImageFrame(None, self._speaking_image_bytes)
         yield frame
-        yield ImageQueueFrame(None, self._waiting_image_bytes)
+        yield ImageFrame(None, self._waiting_image_bytes)
 
 
 async def main(room_url: str, token):

--- a/src/examples/foundational/08-bots-arguing.py
+++ b/src/examples/foundational/08-bots-arguing.py
@@ -6,7 +6,7 @@ from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from dailyai.services.fal_ai_services import FalImageGenService
-from dailyai.pipeline.frames import AudioQueueFrame, ImageQueueFrame
+from dailyai.pipeline.frames import AudioFrame, ImageFrame
 
 from examples.foundational.support.runner import configure
 
@@ -90,8 +90,8 @@ async def main(room_url: str):
                 )
                 await transport.send_queue.put(
                     [
-                        ImageQueueFrame(None, image_data1[1]),
-                        AudioQueueFrame(audio1),
+                        ImageFrame(None, image_data1[1]),
+                        AudioFrame(audio1),
                     ]
                 )
 
@@ -102,8 +102,8 @@ async def main(room_url: str):
                 )
                 await transport.send_queue.put(
                     [
-                        ImageQueueFrame(None, image_data2[1]),
-                        AudioQueueFrame(audio2),
+                        ImageFrame(None, image_data2[1]),
+                        AudioFrame(audio2),
                     ]
                 )
 

--- a/src/examples/foundational/11-sound-effects.py
+++ b/src/examples/foundational/11-sound-effects.py
@@ -9,7 +9,7 @@ from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from dailyai.pipeline.aggregators import LLMContextAggregator, LLMUserContextAggregator, LLMAssistantContextAggregator
 from dailyai.services.ai_services import AIService, FrameLogger
-from dailyai.pipeline.frames import QueueFrame, AudioQueueFrame, LLMResponseEndQueueFrame, LLMMessagesQueueFrame
+from dailyai.pipeline.frames import Frame, AudioFrame, LLMResponseEndFrame, LLMMessagesQueueFrame
 from typing import AsyncGenerator
 
 from examples.foundational.support.runner import configure
@@ -40,9 +40,9 @@ class OutboundSoundEffectWrapper(AIService):
     def __init__(self):
         pass
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
-        if isinstance(frame, LLMResponseEndQueueFrame):
-            yield AudioQueueFrame(sounds["ding1.wav"])
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
+        if isinstance(frame, LLMResponseEndFrame):
+            yield AudioFrame(sounds["ding1.wav"])
             # In case anything else up the stack needs it
             yield frame
         else:
@@ -53,9 +53,9 @@ class InboundSoundEffectWrapper(AIService):
     def __init__(self):
         pass
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
         if isinstance(frame, LLMMessagesQueueFrame):
-            yield AudioQueueFrame(sounds["ding2.wav"])
+            yield AudioFrame(sounds["ding2.wav"])
             # In case anything else up the stack needs it
             yield frame
         else:
@@ -86,7 +86,7 @@ async def main(room_url: str, token):
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):
             await tts.say("Hi, I'm listening!", transport.send_queue)
-            await transport.send_queue.put(AudioQueueFrame(sounds["ding1.wav"]))
+            await transport.send_queue.put(AudioFrame(sounds["ding1.wav"]))
 
         async def handle_transcriptions():
             messages = [

--- a/src/examples/foundational/13a-whisper-local.py
+++ b/src/examples/foundational/13a-whisper-local.py
@@ -1,7 +1,7 @@
 import argparse
 import asyncio
 import wave
-from dailyai.pipeline.frames import EndStreamQueueFrame, TranscriptionQueueFrame
+from dailyai.pipeline.frames import EndFrame, TranscriptionQueueFrame
 
 from dailyai.services.local_transport_service import LocalTransportService
 from dailyai.services.whisper_ai_services import WhisperSTTService
@@ -30,7 +30,7 @@ async def main(room_url: str):
             print("got item from queue", item)
             if isinstance(item, TranscriptionQueueFrame):
                 print(item.text)
-            elif isinstance(item, EndStreamQueueFrame):
+            elif isinstance(item, EndFrame):
                 break
         print("handle_transcription done")
 
@@ -38,7 +38,7 @@ async def main(room_url: str):
         await stt.run_to_queue(
             transcription_output_queue, transport.get_receive_frames()
         )
-        await transcription_output_queue.put(EndStreamQueueFrame())
+        await transcription_output_queue.put(EndFrame())
         print("handle speaker done.")
 
     async def run_until_done():

--- a/src/examples/image-gen.py
+++ b/src/examples/image-gen.py
@@ -7,7 +7,7 @@ import random
 
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
-from dailyai.pipeline.frames import QueueFrame, FrameType
+from dailyai.pipeline.frames import Frame, FrameType
 from dailyai.services.fal_ai_services import FalImageGenService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 
@@ -45,7 +45,7 @@ async def main(room_url: str, token):
             print(f"finder: {finder}")
             if finder >= 0:
                 async for audio in tts.run_tts(f"Resetting."):
-                    transport.output_queue.put(QueueFrame(FrameType.AUDIO_FRAME, audio))
+                    transport.output_queue.put(Frame(FrameType.AUDIO_FRAME, audio))
                 sentence = ""
                 continue
             # todo: we could differentiate between transcriptions from different participants
@@ -54,12 +54,12 @@ async def main(room_url: str, token):
             # TODO: Cache this audio
             phrase = random.choice(["OK.", "Got it.", "Sure.", "You bet.", "Sure thing."])
             async for audio in tts.run_tts(phrase):
-                transport.output_queue.put(QueueFrame(FrameType.AUDIO_FRAME, audio))
+                transport.output_queue.put(Frame(FrameType.AUDIO_FRAME, audio))
             img_result = img.run_image_gen(sentence, "1024x1024")
             awaited_img = await asyncio.gather(img_result)
             transport.output_queue.put(
                 [
-                    QueueFrame(FrameType.IMAGE_FRAME, awaited_img[0][1]),
+                    Frame(FrameType.IMAGE_FRAME, awaited_img[0][1]),
                 ]
             )
 
@@ -72,7 +72,7 @@ async def main(room_url: str, token):
             audio_generator = tts.run_tts(
                 f"Hello, {participant['info']['userName']}! Describe an image and I'll create it. To start over, just say 'start over'.")
             async for audio in audio_generator:
-                transport.output_queue.put(QueueFrame(FrameType.AUDIO_FRAME, audio))
+                transport.output_queue.put(Frame(FrameType.AUDIO_FRAME, audio))
 
     transport.transcription_settings["extra"]["punctuate"] = False
     transport.transcription_settings["extra"]["endpointing"] = False

--- a/src/examples/internal/11a-dial-out.py
+++ b/src/examples/internal/11a-dial-out.py
@@ -7,7 +7,7 @@ from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
 from dailyai.pipeline.aggregators import LLMContextAggregator
 from dailyai.services.ai_services import AIService, FrameLogger
-from dailyai.pipeline.frames import QueueFrame, AudioQueueFrame, LLMResponseEndQueueFrame, LLMMessagesQueueFrame
+from dailyai.pipeline.frames import Frame, AudioFrame, LLMResponseEndFrame, LLMMessagesQueueFrame
 from typing import AsyncGenerator
 
 from examples.foundational.support.runner import configure
@@ -34,9 +34,9 @@ class OutboundSoundEffectWrapper(AIService):
     def __init__(self):
         pass
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
-        if isinstance(frame, LLMResponseEndQueueFrame):
-            yield AudioQueueFrame(sounds["ding1.wav"])
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
+        if isinstance(frame, LLMResponseEndFrame):
+            yield AudioFrame(sounds["ding1.wav"])
             # In case anything else up the stack needs it
             yield frame
         else:
@@ -47,9 +47,9 @@ class InboundSoundEffectWrapper(AIService):
     def __init__(self):
         pass
 
-    async def process_frame(self, frame: QueueFrame) -> AsyncGenerator[QueueFrame, None]:
+    async def process_frame(self, frame: Frame) -> AsyncGenerator[Frame, None]:
         if isinstance(frame, LLMMessagesQueueFrame):
-            yield AudioQueueFrame(sounds["ding2.wav"])
+            yield AudioFrame(sounds["ding2.wav"])
             # In case anything else up the stack needs it
             yield frame
         else:
@@ -79,7 +79,7 @@ async def main(room_url: str, token, phone):
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):
             await tts.say("Hi, I'm listening!", transport.send_queue)
-            await transport.send_queue.put(AudioQueueFrame(sounds["ding1.wav"]))
+            await transport.send_queue.put(AudioFrame(sounds["ding1.wav"]))
 
         async def handle_transcriptions():
             messages = [


### PR DESCRIPTION
The `.*QueueFrame` naming was feeling increasingly clunky to me, so I removed the `Queue` part.