### PR TITLE
Optimize pipeline processing

### DIFF
--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -138,6 +138,7 @@ class TTSService(AIService):
             text = frame.text
         else:
             self.current_sentence += frame.text
+            print(f"current sentence: {self.current_sentence}")
             if self.current_sentence.endswith((".", "?", "!")):
                 text = self.current_sentence
                 self.current_sentence = ""

--- a/src/dailyai/services/ai_services.py
+++ b/src/dailyai/services/ai_services.py
@@ -138,7 +138,6 @@ class TTSService(AIService):
             text = frame.text
         else:
             self.current_sentence += frame.text
-            print(f"current sentence: {self.current_sentence}")
             if self.current_sentence.endswith((".", "?", "!")):
                 text = self.current_sentence
                 self.current_sentence = ""

--- a/src/dailyai/tests/test_pipeline.py
+++ b/src/dailyai/tests/test_pipeline.py
@@ -1,5 +1,4 @@
 import asyncio
-from doctest import OutputChecker
 import unittest
 from dailyai.pipeline.aggregators import SentenceAggregator, StatelessTextTransformer
 from dailyai.pipeline.frames import EndFrame, TextFrame

--- a/src/examples/foundational/04-utterance-and-speech.py
+++ b/src/examples/foundational/04-utterance-and-speech.py
@@ -44,7 +44,8 @@ async def main(room_url: str):
         buffer_queue = asyncio.Queue()
         source_queue = asyncio.Queue()
         pipeline = Pipeline(source = source_queue, sink=buffer_queue, processors=[llm, elevenlabs_tts])
-        source_queue.put_nowait(LLMMessagesQueueFrame(messages))
+        await source_queue.put(LLMMessagesQueueFrame(messages))
+        await source_queue.put(EndFrame())
         pipeline_run_task = pipeline.run_pipeline()
 
         @transport.event_handler("on_first_other_participant_joined")

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -47,7 +47,20 @@ async def main(room_url):
 
         source_queue = asyncio.Queue()
 
-        for month in ["January", "February"]:
+        for month in [
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+        ]:
             messages = [
                 {
                     "role": "system",

--- a/src/examples/foundational/06-listen-and-respond.py
+++ b/src/examples/foundational/06-listen-and-respond.py
@@ -51,8 +51,8 @@ async def main(room_url: str, token):
                 tma_in,
                 llm,
                 fl2,
+                tts,
                 tma_out,
-                tts
             ],
         )
         await transport.run_uninterruptible_pipeline(pipeline)


### PR DESCRIPTION
I realized that my new pipeline implementation had a problem. It effectively did this:
```
frames = []
async for frame in frame_processor_1.process_frame(source.get()):
  frames.append(frame)y

next_frames = []
async for frame in frame_processor_2.process_frame(frames.pop(0)):
  next_frames.append(frame)

...etc
```

That is, it was waiting for each `frame_processor` iterator to complete before sending those frames to the next processor in the pipeline. This was wrong!

I changed it so it's recursive and each individual frame from a processor will be passed to the next processor in the pipeline. This mirrors how it worked when we nested generators initially.

I could change this to not be recursive and to instead use a queue, but the depth of recursion is limited by the number of processors in the pipeline, so it feels safe. Happy to hear other thoughts about that though!