### PR TITLE
Don't do time-consuming processing in `on_other_joined_event`

### DIFF
--- a/src/dailyai/services/fal_ai_services.py
+++ b/src/dailyai/services/fal_ai_services.py
@@ -32,8 +32,8 @@ class FalImageGenService(ImageGenService):
     async def run_image_gen(self, sentence) -> tuple[str, bytes]:
         def get_image_url(sentence, size):
             handler = fal.apps.submit(
-                "110602490-fast-sdxl",
-                #"fal-ai/fast-sdxl",
+                #"110602490-fast-sdxl",
+                "fal-ai/fast-sdxl",
                 arguments={"prompt": sentence},
             )
             for event in handler.iter_events():

--- a/src/dailyai/services/fal_ai_services.py
+++ b/src/dailyai/services/fal_ai_services.py
@@ -32,8 +32,8 @@ class FalImageGenService(ImageGenService):
     async def run_image_gen(self, sentence) -> tuple[str, bytes]:
         def get_image_url(sentence, size):
             handler = fal.apps.submit(
-                # "110602490-fast-sdxl",
-                "fal-ai/fast-sdxl",
+                "110602490-fast-sdxl",
+                #"fal-ai/fast-sdxl",
                 arguments={"prompt": sentence},
             )
             for event in handler.iter_events():

--- a/src/examples/foundational/01-say-one-thing.py
+++ b/src/examples/foundational/01-say-one-thing.py
@@ -36,7 +36,6 @@ async def main(room_url):
             nonlocal participant_name
 
             await other_joined_event.wait()
-            print("done waiting")
             await tts.say(
                 "Hello there, " + participant_name + "!",
                 transport.send_queue,

--- a/src/examples/foundational/02-llm-say-one-thing.py
+++ b/src/examples/foundational/02-llm-say-one-thing.py
@@ -47,8 +47,7 @@ async def main(room_url):
             await other_joined_event.wait()
             await tts.run_to_queue(
                 transport.send_queue,
-                llm.run([LLMMessagesQueueFrame(messages)]),
-                add_end_of_stream=True
+                llm.run([LLMMessagesQueueFrame(messages)])
             )
             await transport.stop_when_done()
 

--- a/src/examples/foundational/05-sync-speech-and-image.py
+++ b/src/examples/foundational/05-sync-speech-and-image.py
@@ -140,12 +140,18 @@ async def main(room_url):
         )
         pipeline_task = pipeline.run_pipeline()
 
+        other_joined = asyncio.Event()
+
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):
+            other_joined.set()
+
+        async def show_calendar():
+            await other_joined.wait()
             await pipeline_task
             await transport.stop_when_done()
 
-        await transport.run()
+        await asyncio.gather(transport.run(), show_calendar())
 
 
 if __name__ == "__main__":

--- a/src/examples/foundational/06-listen-and-respond.py
+++ b/src/examples/foundational/06-listen-and-respond.py
@@ -49,7 +49,7 @@ async def main(room_url: str, token):
         async def on_first_other_participant_joined(transport):
             await tts.say("Hi, I'm listening!", transport.send_queue)
 
-        async def handle_transcriptions():
+        async def have_conversation():
             messages = [
                 {
                     "role": "system",
@@ -75,7 +75,7 @@ async def main(room_url: str, token):
 
         transport.transcription_settings["extra"]["endpointing"] = True
         transport.transcription_settings["extra"]["punctuate"] = True
-        await asyncio.gather(transport.run(), handle_transcriptions())
+        await asyncio.gather(transport.run(), have_conversation())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Anything we do in an event handler blocks other event handlers from being called. So, for many of the samples, it's much better to have an asynchronous function waiting on an event that gets triggered by the `on_other_participant_joined` event.