### PR TITLE
Remove unused requirements file

### DIFF
--- a/src/dailyai/requirements.txt
+++ b/src/dailyai/requirements.txt
@@ -1,3 +1,0 @@
-Pillow==10.1.0
-typing_extensions==4.9.0
-faster-whisper==0.10.0


### PR DESCRIPTION
This file isn't used and I think was mistakenly merged. Dependabot was complaining about the version of Pillow, but would rather just remove the file entirely.