### PR TITLE
Remove run_to_queue and run from AIService class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dailyai"
-version = "0.0.1"
+version = "0.0.3"
 description = "An open source framework for real-time, multi-modal, conversational AI applications"
 license = { text = "BSD 2-Clause License" }
 readme = "README.md"

--- a/src/dailyai/pipeline/merge_pipeline.py
+++ b/src/dailyai/pipeline/merge_pipeline.py
@@ -1,0 +1,21 @@
+from typing import List
+from dailyai.pipeline.frames import EndFrame, EndPipeFrame
+from dailyai.pipeline.pipeline import Pipeline
+
+
+class SequentialMergePipeline(Pipeline):
+    """This class merges the sink queues from a list of pipelines. Frames from
+    each pipeline's sink are merged in the order of pipelines in the list."""
+    def __init__(self, pipelines:List[Pipeline]):
+        super().__init__([])
+        self.pipelines = pipelines
+
+    async def run_pipeline(self):
+        for pipeline in self.pipelines:
+            while True:
+                frame = await pipeline.sink.get()
+                if isinstance(frame, EndFrame) or isinstance(frame, EndPipeFrame):
+                    break
+                await self.sink.put(frame)
+
+        await self.sink.put(EndFrame())

--- a/src/dailyai/services/azure_ai_services.py
+++ b/src/dailyai/services/azure_ai_services.py
@@ -64,13 +64,17 @@ class AzureTTSService(TTSService):
 
 class AzureLLMService(BaseOpenAILLMService):
     def __init__(self, *, api_key, endpoint, api_version="2023-12-01-preview", model):
-        super().__init__(model)
+        self._endpoint = endpoint
+        self._api_version = api_version
 
-        # This overrides the client created by the super class init
+        super().__init__(api_key=api_key, model=model)
+        self._model: str = model
+
+    def create_client(self, api_key=None, base_url=None):
         self._client = AsyncAzureOpenAI(
             api_key=api_key,
-            azure_endpoint=endpoint,
-            api_version=api_version,
+            azure_endpoint=self._endpoint,
+            api_version=self._api_version,
         )
 
 

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -151,10 +151,9 @@ class BaseTransportService:
 
         pipeline_task = None
         if pipeline:
-            pipeline.set_sink(self.send_queue)
-            if override_pipeline_source_queue:
-                pipeline.set_source(self.receive_queue)
-            pipeline_task =  asyncio.create_task(pipeline.run_pipeline())
+            pipeline_task = asyncio.create_task(
+                self.run_pipeline(pipeline, override_pipeline_source_queue)
+            )
 
         try:
             while time.time() < self._expiration and not self._stop_threads.is_set():
@@ -181,6 +180,12 @@ class BaseTransportService:
 
         if self._vad_enabled:
             self._vad_thread.join()
+
+    async def run_pipeline(self, pipeline:Pipeline, override_pipeline_source_queue=True):
+        pipeline.set_sink(self.send_queue)
+        if override_pipeline_source_queue:
+            pipeline.set_source(self.receive_queue)
+        await pipeline.run_pipeline()
 
     async def run_interruptible_pipeline(
         self,

--- a/src/dailyai/services/daily_transport_service.py
+++ b/src/dailyai/services/daily_transport_service.py
@@ -219,7 +219,8 @@ class DailyTransportService(BaseTransportService, EventHandler):
         pass
 
     def call_joined(self, join_data, client_error):
-        self._logger.info(f"Call_joined: {join_data}, {client_error}")
+        #self._logger.info(f"Call_joined: {join_data}, {client_error}")
+        pass
 
     def dialout(self, number):
         self.client.start_dialout({"phoneNumber": number})

--- a/src/dailyai/services/openai_api_llm_service.py
+++ b/src/dailyai/services/openai_api_llm_service.py
@@ -35,6 +35,9 @@ class BaseOpenAILLMService(LLMService):
     def __init__(self, model: str, api_key=None, base_url=None):
         super().__init__()
         self._model: str = model
+        self.create_client(api_key=api_key, base_url=base_url)
+
+    def create_client(self, api_key=None, base_url=None):
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     async def _stream_chat_completions(

--- a/src/dailyai/tests/test_ai_services.py
+++ b/src/dailyai/tests/test_ai_services.py
@@ -12,7 +12,7 @@ class SimpleAIService(AIService):
 
 
 class TestBaseAIService(unittest.IsolatedAsyncioTestCase):
-    async def test_async_input(self):
+    async def test_simple_processing(self):
         service = SimpleAIService()
 
         input_frames = [
@@ -20,28 +20,10 @@ class TestBaseAIService(unittest.IsolatedAsyncioTestCase):
             EndFrame()
         ]
 
-        async def iterate_frames() -> AsyncGenerator[Frame, None]:
-            for frame in input_frames:
-                yield frame
-
         output_frames = []
-        async for frame in service.run(iterate_frames()):
-            output_frames.append(frame)
-
-        self.assertEqual(input_frames, output_frames)
-
-    async def test_nonasync_input(self):
-        service = SimpleAIService()
-
-        input_frames = [TextFrame("hello"), EndFrame()]
-
-        def iterate_frames() -> Generator[Frame, None, None]:
-            for frame in input_frames:
-                yield frame
-
-        output_frames = []
-        async for frame in service.run(iterate_frames()):
-            output_frames.append(frame)
+        for input_frame in input_frames:
+            async for output_frame in service.process_frame(input_frame):
+                output_frames.append(output_frame)
 
         self.assertEqual(input_frames, output_frames)
 

--- a/src/examples/foundational/04-utterance-and-speech.py
+++ b/src/examples/foundational/04-utterance-and-speech.py
@@ -3,12 +3,13 @@ import logging
 import os
 
 import aiohttp
+from dailyai.pipeline.merge_pipeline import SequentialMergePipeline
 from dailyai.pipeline.pipeline import Pipeline
 
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.azure_ai_services import AzureLLMService, AzureTTSService
 from dailyai.services.deepgram_ai_services import DeepgramTTSService
-from dailyai.pipeline.frames import EndFrame, LLMMessagesQueueFrame
+from dailyai.pipeline.frames import EndFrame, EndPipeFrame, LLMMessagesQueueFrame, TextFrame
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from examples.support.runner import configure
 
@@ -53,49 +54,24 @@ async def main(room_url: str):
         # Start a task to run the LLM to create a joke, and convert the LLM output to audio frames. This task
         # will run in parallel with generating and speaking the audio for static text, so there's no delay to
         # speak the LLM response.
-        buffer_queue = asyncio.Queue()
-        source_queue = asyncio.Queue()
-        pipeline = Pipeline(
-            source=source_queue, sink=buffer_queue, processors=[llm, elevenlabs_tts]
+        llm_pipeline = Pipeline([llm, elevenlabs_tts])
+        await llm_pipeline.queue_frames([LLMMessagesQueueFrame(messages), EndPipeFrame()])
+
+        simple_tts_pipeline = Pipeline([azure_tts])
+        await simple_tts_pipeline.queue_frames(
+            [
+                TextFrame("My friend the LLM is going to tell a joke about llamas"),
+                EndPipeFrame(),
+            ]
         )
-        await source_queue.put(LLMMessagesQueueFrame(messages))
-        await source_queue.put(EndFrame())
-        pipeline_run_task = pipeline.run_pipeline()
 
-        other_participant_joined = asyncio.Event()
+        merge_pipeline = SequentialMergePipeline([simple_tts_pipeline, llm_pipeline])
 
-        @transport.event_handler("on_first_other_participant_joined")
-        async def on_first_other_participant_joined(transport):
-            other_participant_joined.set()
-
-        async def say_something():
-            await other_participant_joined.wait()
-
-            await azure_tts.say(
-                "My friend the LLM is now going to tell a joke about llamas.",
-                transport.send_queue,
-            )
-
-            # khk: deepgram_tts.say() doesn't seem to put bytes in the transport
-            # queue. I get a debug log line that indicates we're set up okay, but
-            # no further log lines or audio bytes. debug this later:
-            #   20 2024-03-10 13:24:46,235 Running deepgram tts for My friend the LLM is now going to tell a joke about llamas.
-            # await deepgram_tts.say(
-            #    "My friend the LLM is now going to tell a joke about llamas.",
-            #    transport.send_queue,
-            # )
-
-            async def buffer_to_send_queue():
-                while True:
-                    frame = await buffer_queue.get()
-                    await transport.send_queue.put(frame)
-                    buffer_queue.task_done()
-                    if isinstance(frame, EndFrame):
-                        break
-
-            await asyncio.gather(pipeline_run_task, buffer_to_send_queue())
-
-        await asyncio.gather(transport.run(), say_something())
+        await asyncio.gather(
+            transport.run(merge_pipeline),
+            simple_tts_pipeline.run_pipeline(),
+            llm_pipeline.run_pipeline(),
+        )
 
 
 if __name__ == "__main__":

--- a/src/examples/foundational/07-interruptible.py
+++ b/src/examples/foundational/07-interruptible.py
@@ -49,7 +49,7 @@ async def main(room_url: str, token):
 
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):
-            await tts.say("Hi, I'm listening!", transport.send_queue)
+            await transport.say("Hi, I'm listening!", tts)
 
         async def run_conversation():
             messages = [

--- a/src/examples/starter-apps/chatbot.py
+++ b/src/examples/starter-apps/chatbot.py
@@ -6,9 +6,7 @@ from PIL import Image
 from typing import AsyncGenerator
 
 from dailyai.pipeline.aggregators import (
-    LLMAssistantContextAggregator,
     LLMResponseAggregator,
-    LLMUserContextAggregator,
     UserResponseAggregator,
 )
 from dailyai.pipeline.frames import (
@@ -16,15 +14,12 @@ from dailyai.pipeline.frames import (
     SpriteFrame,
     Frame,
     LLMResponseEndFrame,
-    LLMResponseStartFrame,
     LLMMessagesQueueFrame,
-    UserStartedSpeakingFrame,
     AudioFrame,
     PipelineStartedFrame,
 )
 from dailyai.services.ai_services import AIService
 from dailyai.pipeline.pipeline import Pipeline
-from dailyai.services.ai_services import FrameLogger
 from dailyai.services.daily_transport_service import DailyTransportService
 from dailyai.services.open_ai_services import OpenAILLMService
 from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
@@ -130,7 +125,7 @@ async def main(room_url: str, token):
         @transport.event_handler("on_first_other_participant_joined")
         async def on_first_other_participant_joined(transport):
             print(f"!!! in here, pipeline.source is {pipeline.source}")
-            await pipeline.queue_frames(LLMMessagesQueueFrame(messages))
+            await pipeline.queue_frames([LLMMessagesQueueFrame(messages)])
 
         async def run_conversation():
 

--- a/src/examples/starter-apps/storybot.py
+++ b/src/examples/starter-apps/storybot.py
@@ -273,7 +273,7 @@ async def main(room_url: str, token):
                     lra,
                 ]
             )
-            await transport.run_uninterruptible_pipeline(
+            await transport.run_pipeline(
                 pipeline,
             )
 


### PR DESCRIPTION
I wanted to clean up what it means to be a FrameProcessor vs what it means to be a pipeline. Here's my thesis:

* a FrameProcessor consumes a single frame and emits 0 or more frames
* a pipeline sends Frames to FrameProcessors

The AIService class muddied this a little bit (because originally it was both a frame processor *and* a one-step pipeline).

This PR does a few things:

* removes the `run` and `run_to_queue` methods from the AIService class.
* updates the `queue_frames` method on the Pipeline to consume an iterable rather than a Frame or a List
* adds a `pipeline` parameter to the `transport.run` method. If a pipeline is provided, the `run` method will set its queues to point to the transport, run it until it ends, then exit.
* adds a `say` convenience method to the _transport_, rather than an AIService.
* updates the samples & apps to use pipelines in places where they'd used `run_to_queue`.