### PR TITLE
Support for app messages

### DIFF
--- a/src/dailyai/pipeline/frames.py
+++ b/src/dailyai/pipeline/frames.py
@@ -95,9 +95,19 @@ class OpenAILLMContextFrame(Frame):
     context: OpenAILLMContext
 
 
-class AppMessageQueueFrame(Frame):
+@dataclass()
+class ReceivedAppMessageFrame(Frame):
     message: Any
-    participantId: str
+    sender: str
+
+    def __str__(self):
+        return f"ReceivedAppMessageFrame: sender: {self.sender}, message: {self.message}"
+
+
+@dataclass()
+class SendAppMessageFrame(Frame):
+    message: Any
+    participantId: str | None
 
 
 class UserStartedSpeakingFrame(Frame):

--- a/src/dailyai/pipeline/frames.py
+++ b/src/dailyai/pipeline/frames.py
@@ -109,6 +109,9 @@ class SendAppMessageFrame(Frame):
     message: Any
     participantId: str | None
 
+    def __str__(self):
+        return f"SendAppMessageFrame: participantId: {self.participantId}, message: {self.message}"
+
 
 class UserStartedSpeakingFrame(Frame):
     pass

--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -13,7 +13,6 @@ from enum import Enum
 from dailyai.pipeline.frame_processor import FrameProcessor
 
 from dailyai.pipeline.frames import (
-    ReceivedAppMessageFrame,
     SendAppMessageFrame,
     AudioFrame,
     EndFrame,


### PR DESCRIPTION
Added support for app messages. A few notes:

* I separated out a "received app message" from a "send app message" so we don't get into feedback loops where incoming app messages are ignored and passed through to the transport, to be sent again, etc
* I went back and forth on adding support for this to the base transport and settled on "it's less confusing if it's there, but unsupported." Could probably be convinced otherwise
* this feels pretty straightforward. One thing to note: To test this I changed the 06- sample and added a frame processor that listened for LLM output and yielded an app message on the LLMResponseEndFrame. This worked, *but* the output wasn't sent until the audio was done speaking, because we process the audio synchronously and don't get to the frame until the audio's done. We could get around this with a gate aggregator. I can make a sample app that does this or maybe add it to the "llama joke" one.