### PR TITLE
avoid using pyaudio if not needed

### DIFF
--- a/src/dailyai/services/base_transport_service.py
+++ b/src/dailyai/services/base_transport_service.py
@@ -3,7 +3,6 @@ import asyncio
 import itertools
 import logging
 import numpy as np
-import pyaudio
 import torch
 import queue
 import threading
@@ -57,12 +56,7 @@ def int2float(sound):
     return sound
 
 
-FORMAT = pyaudio.paInt16
-CHANNELS = 1
 SAMPLE_RATE = 16000
-CHUNK = int(SAMPLE_RATE / 10)
-
-audio = pyaudio.PyAudio()
 
 
 class VADState(Enum):


### PR DESCRIPTION
Initializing pyaudio and not deinitializing properly might cause system audio issues (experienced it in daily-python). So, since we are not using it for anything in the base transport, we should just remove it.