### PR TITLE
fix: force overriding environment variables from .env files

### DIFF
--- a/examples/foundational/01-say-one-thing.py
+++ b/examples/foundational/01-say-one-thing.py
@@ -11,7 +11,7 @@ from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/02-llm-say-one-thing.py
+++ b/examples/foundational/02-llm-say-one-thing.py
@@ -13,7 +13,7 @@ from dailyai.services.open_ai_services import OpenAILLMService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/03-still-frame.py
+++ b/examples/foundational/03-still-frame.py
@@ -11,7 +11,7 @@ from dailyai.services.fal_ai_services import FalImageGenService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/04-utterance-and-speech.py
+++ b/examples/foundational/04-utterance-and-speech.py
@@ -15,7 +15,7 @@ from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/05-sync-speech-and-image.py
+++ b/examples/foundational/05-sync-speech-and-image.py
@@ -31,7 +31,7 @@ from dailyai.services.fal_ai_services import FalImageGenService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/06-listen-and-respond.py
+++ b/examples/foundational/06-listen-and-respond.py
@@ -16,7 +16,7 @@ from dailyai.pipeline.aggregators import (
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/06a-image-sync.py
+++ b/examples/foundational/06a-image-sync.py
@@ -19,7 +19,7 @@ from dailyai.services.fal_ai_services import FalImageGenService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/07-interruptible.py
+++ b/examples/foundational/07-interruptible.py
@@ -16,7 +16,7 @@ from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/08-bots-arguing.py
+++ b/examples/foundational/08-bots-arguing.py
@@ -15,7 +15,7 @@ from dailyai.pipeline.frames import AudioFrame, EndFrame, ImageFrame, LLMMessage
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/10-wake-word.py
+++ b/examples/foundational/10-wake-word.py
@@ -25,7 +25,7 @@ from dailyai.services.ai_services import AIService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/11-sound-effects.py
+++ b/examples/foundational/11-sound-effects.py
@@ -23,7 +23,7 @@ from typing import AsyncGenerator
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/foundational/13-whisper-transcription.py
+++ b/examples/foundational/13-whisper-transcription.py
@@ -7,7 +7,7 @@ from dailyai.services.whisper_ai_services import WhisperSTTService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/internal/11a-dial-out.py
+++ b/examples/internal/11a-dial-out.py
@@ -13,7 +13,7 @@ from typing import AsyncGenerator
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 sounds = {}
 sound_files = [

--- a/examples/server/daily-bot-manager.py
+++ b/examples/server/daily-bot-manager.py
@@ -9,7 +9,7 @@ from flask_cors import CORS
 from auth import get_meeting_token
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 app = Flask(__name__)
 CORS(app)

--- a/examples/starter-apps/chatbot.py
+++ b/examples/starter-apps/chatbot.py
@@ -27,7 +27,7 @@ from dailyai.services.elevenlabs_ai_service import ElevenLabsTTSService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/starter-apps/patient-intake.py
+++ b/examples/starter-apps/patient-intake.py
@@ -35,7 +35,7 @@ from openai.types.chat import (
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format="%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/starter-apps/storybot.py
+++ b/examples/starter-apps/storybot.py
@@ -37,7 +37,7 @@ from dailyai.services.ai_services import FrameLogger, AIService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")

--- a/examples/starter-apps/translator.py
+++ b/examples/starter-apps/translator.py
@@ -17,7 +17,7 @@ from dailyai.services.open_ai_services import OpenAILLMService
 from runner import configure
 
 from dotenv import load_dotenv
-load_dotenv()
+load_dotenv(override=True)
 
 logging.basicConfig(format=f"%(levelno)s %(asctime)s %(message)s")
 logger = logging.getLogger("dailyai")


### PR DESCRIPTION
By default load_dotenv [does not override existing environment variables.](https://pypi.org/project/python-dotenv/#:~:text=By%20default%2C%20load_dotenv%20doesn%27t%20override%20existing%20environment%20variables.) This has confused some users who are newer to Python, as this is not the same behavior as other programming languages like Node Js. This reverses the default behavior.