### PR TITLE
Add logging for pipeline

### DIFF
--- a/examples/foundational/04-utterance-and-speech.py
+++ b/examples/foundational/04-utterance-and-speech.py
@@ -65,7 +65,7 @@ async def main(room_url: str):
         simple_tts_pipeline = Pipeline([azure_tts])
         await simple_tts_pipeline.queue_frames(
             [
-                TextFrame("My friend the LLM is going to tell a joke about llamas"),
+                TextFrame("My friend the LLM is going to tell a joke about llamas."),
                 EndPipeFrame(),
             ]
         )

--- a/src/dailyai/pipeline/frame_processor.py
+++ b/src/dailyai/pipeline/frame_processor.py
@@ -29,3 +29,6 @@ class FrameProcessor:
     async def interrupted(self) -> None:
         """Handle any cleanup if the pipeline was interrupted."""
         pass
+
+    def __str__(self):
+        return self.__class__.__name__

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,6 +1,9 @@
 import asyncio
 import unittest
+from unittest.mock import Mock
+
 from dailyai.pipeline.aggregators import SentenceAggregator, StatelessTextTransformer
+from dailyai.pipeline.frame_processor import FrameProcessor
 from dailyai.pipeline.frames import EndFrame, TextFrame
 
 from dailyai.pipeline.pipeline import Pipeline
@@ -57,3 +60,52 @@ class TestDailyPipeline(unittest.IsolatedAsyncioTestCase):
             TextFrame(" "),
         )
         self.assertIsInstance(await outgoing_queue.get(), EndFrame)
+
+
+class TestLogFrame(unittest.TestCase):
+    class MockProcessor(FrameProcessor):
+        def __init__(self, name):
+            self.name = name
+
+        def __str__(self):
+            return self.name
+
+    def setUp(self):
+        self.processor1 = self.MockProcessor('processor1')
+        self.processor2 = self.MockProcessor('processor2')
+        self.pipeline = Pipeline(
+            processors=[self.processor1, self.processor2])
+        self.pipeline._name = 'MyClass'
+        self.pipeline._logger = Mock()
+
+    def test_log_frame_from_source(self):
+        frame = Mock(__class__=Mock(__name__='MyFrame'))
+        self.pipeline._log_frame(frame, depth=1)
+        self.pipeline._logger.debug.assert_called_once_with(
+            'MyClass  source -> MyFrame -> processor1')
+
+    def test_log_frame_to_sink(self):
+        frame = Mock(__class__=Mock(__name__='MyFrame'))
+        self.pipeline._log_frame(frame, depth=3)
+        self.pipeline._logger.debug.assert_called_once_with(
+            'MyClass      processor2 -> MyFrame -> sink')
+
+    def test_log_frame_repeated_log(self):
+        frame = Mock(__class__=Mock(__name__='MyFrame'))
+        self.pipeline._log_frame(frame, depth=2)
+        self.pipeline._logger.debug.assert_called_once_with(
+            'MyClass    processor1 -> MyFrame -> processor2')
+        self.pipeline._log_frame(frame, depth=2)
+        self.pipeline._logger.debug.assert_called_with('MyClass    ... repeated')
+
+    def test_log_frame_reset_repeated_log(self):
+        frame1 = Mock(__class__=Mock(__name__='MyFrame1'))
+        frame2 = Mock(__class__=Mock(__name__='MyFrame2'))
+        self.pipeline._log_frame(frame1, depth=2)
+        self.pipeline._logger.debug.assert_called_once_with(
+            'MyClass    processor1 -> MyFrame1 -> processor2')
+        self.pipeline._log_frame(frame1, depth=2)
+        self.pipeline._logger.debug.assert_called_with('MyClass    ... repeated')
+        self.pipeline._log_frame(frame2, depth=2)
+        self.pipeline._logger.debug.assert_called_with(
+            'MyClass    processor1 -> MyFrame2 -> processor2')


### PR DESCRIPTION
This PR adds some visual logging to watch frames go through pipelines.

Here's an example from sample 04. This sample uses two Pipelines with a SequentialMergePipeline, so the hardcoded one runs first. I *think* this makes it easy to see which frames are being passed along.

Note that I drop Audio frames. I might change this to show the first and then an ellipse or something until there's something that's *not* an audio frame.

```
10 2024-03-27 18:46:04,228   source -> TextFrame: "My friend the LLM is going to tell a joke about llamas" -> AzureTTSService
10 2024-03-27 18:46:04,229     AzureTTSService -> TextFrame: "My friend the LLM is going to tell a joke about llamas" -> AzureTTSService
10 2024-03-27 18:46:04,229   source -> EndPipeFrame -> AzureTTSService
10 2024-03-27 18:46:04,229     AzureTTSService -> EndPipeFrame -> AzureTTSService
10 2024-03-27 18:46:04,229       AzureTTSService -> TTSStartFrame -> sink
20 2024-03-27 18:46:04,229 🎬 Starting frame consumer thread
20 2024-03-27 18:46:04,229 Running azure tts
10 2024-03-27 18:46:04,230   source -> LLMMessagesQueueFrame -> ElevenLabsTTSService
10 2024-03-27 18:46:04,230     ElevenLabsTTSService -> LLMMessagesQueueFrame -> AzureLLMService
10 2024-03-27 18:46:04,230       AzureLLMService -> LLMResponseStartFrame -> ElevenLabsTTSService
10 2024-03-27 18:46:04,230         ElevenLabsTTSService -> LLMResponseStartFrame -> sink
10 2024-03-27 18:46:04,230 Generating chat via openai: [{"content": "tell the user a joke about llamas", "role": "system", "name": "system"}]
20 2024-03-27 18:46:04,863 === OpenAI LLM TTFB: 0.6326563358306885
20 2024-03-27 18:46:05,412 Got azure tts result
20 2024-03-27 18:46:05,412 Returning result
10 2024-03-27 18:46:05,412       AzureTTSService -> TTSEndFrame -> sink
10 2024-03-27 18:46:05,412       AzureTTSService -> TextFrame: "My friend the LLM is going to tell a joke about llamas" -> sink
10 2024-03-27 18:46:05,412       AzureTTSService -> EndPipeFrame -> sink
10 2024-03-27 18:46:05,827       AzureLLMService -> TextFrame: "Why" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,828       AzureLLMService -> TextFrame: " don" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,829       AzureLLMService -> TextFrame: "'t" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,829       AzureLLMService -> TextFrame: " ll" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,829       AzureLLMService -> TextFrame: "amas" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,829       AzureLLMService -> TextFrame: " ever" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,830       AzureLLMService -> TextFrame: " get" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,830       AzureLLMService -> TextFrame: " lost" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,830       AzureLLMService -> TextFrame: "?

" -> ElevenLabsTTSService
10 2024-03-27 18:46:05,830         ElevenLabsTTSService -> TTSStartFrame -> sink
10 2024-03-27 18:46:06,515         ElevenLabsTTSService -> TTSEndFrame -> sink
10 2024-03-27 18:46:06,515         ElevenLabsTTSService -> TextFrame: "Why don't llamas ever get lost?

" -> sink
10 2024-03-27 18:46:06,516       AzureLLMService -> TextFrame: "Because" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,516       AzureLLMService -> TextFrame: " they" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,516       AzureLLMService -> TextFrame: " always" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,517       AzureLLMService -> TextFrame: " take" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,517       AzureLLMService -> TextFrame: " the" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,518       AzureLLMService -> TextFrame: " llama" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,518       AzureLLMService -> TextFrame: "-n" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,518       AzureLLMService -> TextFrame: "ated" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,519       AzureLLMService -> TextFrame: " route" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,519       AzureLLMService -> TextFrame: "!" -> ElevenLabsTTSService
10 2024-03-27 18:46:06,519         ElevenLabsTTSService -> TTSStartFrame -> sink
10 2024-03-27 18:46:07,194         ElevenLabsTTSService -> TTSEndFrame -> sink
10 2024-03-27 18:46:07,194         ElevenLabsTTSService -> TextFrame: "Because they always take the llama-nated route!" -> sink
10 2024-03-27 18:46:07,197       AzureLLMService -> LLMResponseEndFrame -> ElevenLabsTTSService
10 2024-03-27 18:46:07,198         ElevenLabsTTSService -> LLMResponseEndFrame -> sink
10 2024-03-27 18:46:07,198   source -> EndPipeFrame -> ElevenLabsTTSService
10 2024-03-27 18:46:07,198     ElevenLabsTTSService -> EndPipeFrame -> AzureLLMService
10 2024-03-27 18:46:07,198       AzureLLMService -> EndPipeFrame -> ElevenLabsTTSService
10 2024-03-27 18:46:07,198         ElevenLabsTTSService -> EndPipeFrame -> sink
20 2024-03-27 18:46:13,816 Stopping frame consumer thread
```