### PR TITLE
Remove mistakenly-added print statement

### DIFF
--- a/src/dailyai/pipeline/merge_pipeline.py
+++ b/src/dailyai/pipeline/merge_pipeline.py
@@ -15,7 +15,6 @@ class SequentialMergePipeline(Pipeline):
         for idx, pipeline in enumerate(self.pipelines):
             while True:
                 frame = await pipeline.sink.get()
-                print(idx, frame)
                 if isinstance(
                         frame, EndFrame) or isinstance(
                         frame, EndPipeFrame):


### PR DESCRIPTION
I checked in this `print` statement by mistake and it's _very_ noisy in the 04- sample.